### PR TITLE
Add console log to the catch block

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,7 +78,7 @@ function surroundWithTry(selection: vscode.Selection) {
         `${prefix}try {`,
         ...indentLines(lines),
         `${prefix}} catch (error) {`,
-        `${prefix}${indent}`,
+        `${prefix}${indent}console.error(error);`,
         `${prefix}}`,
     ].join('\n');
 }


### PR DESCRIPTION
This behavior is present in the [original extension](https://github.com/JuoCode/vscode-surround) and I found it quite convenient.